### PR TITLE
embedded-hal 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 embedded-hal = "1.0.0"
 
 [dev-dependencies]
-rppal = {version = "0.13.1", features = ["hal"]}
+#rppal = {version = "0.13.1", features = ["hal"]}
 
 [features]
 charlie_bonnet = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ led_shim = []
 matrix = []
 rgb_matrix_5x5 = []
 scroll_phat_hd = []
+pimoroni_rgb_matrix_5x5 = []
 
 [[example]]
 name = "rpi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/gleich/is31fl3731"
 readme = "README.md"
 
 [dependencies]
-embedded-hal = "0.2.6"
+embedded-hal = "1.0.0"
 
 [dev-dependencies]
 rppal = {version = "0.13.1", features = ["hal"]}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,12 @@
 /// Preconfigured devices
 pub mod devices;
 
-use embedded_hal::blocking::delay::DelayMs;
-use embedded_hal::blocking::i2c::Write;
+//use embedded_hal::blocking::delay::DelayMs;
+//use embedded_hal::blocking::i2c::Write;
+
+use embedded_hal as hal;
+use hal::i2c::I2c;
+use hal::delay::DelayNs;
 
 /// A struct to integrate with a new IS31FL3731 powered device.
 pub struct IS31FL3731<I2C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub struct IS31FL3731<I2C> {
 
 impl<I2C, I2cError> IS31FL3731<I2C>
 where
-    I2C: Write<Error = I2cError>,
+    //I2C: Write<Error = I2cError>,
+    I2C: I2c<Error = I2cError>,
 {
     /// Fill the display with a single brightness. The brightness should range from 0 to 255. The reason that blink is an optional is
     /// because you can either set blink to true, set blink to false, or not set blink at all. The
@@ -62,7 +63,8 @@ where
     /// 2. All frames will be cleared.
     /// 3. Audio syncing will be turned off.
     /// 4. The chip will be told that it's being turned back on.
-    pub fn setup<DEL: DelayMs<u8>>(&mut self, delay: &mut DEL) -> Result<(), Error<I2cError>> {
+    //pub fn setup<DEL: DelayMs<u8>>(&mut self, delay: &mut DEL) -> Result<(), Error<I2cError>> {
+    pub fn setup<DEL: DelayNs>(&mut self, delay: &mut DEL) -> Result<(), Error<I2cError>> {
         self.sleep(true)?;
         delay.delay_ms(10);
         self.mode(addresses::PICTURE_MODE)?;
@@ -114,7 +116,8 @@ where
     /// Send a reset message to the slave device. Delay is something that your device's HAL should
     /// provide which allows for the process to sleep for a certain amount of time (in this case 10
     /// MS to perform a reset).
-    pub fn reset<DEL: DelayMs<u8>>(&mut self, delay: &mut DEL) -> Result<(), I2cError> {
+    //pub fn reset<DEL: DelayMs<u8>>(&mut self, delay: &mut DEL) -> Result<(), I2cError> {
+    pub fn reset<DEL: DelayNs>(&mut self, delay: &mut DEL) -> Result<(), I2cError> {
         self.sleep(true)?;
         delay.delay_ms(10);
         self.sleep(false)?;
@@ -148,6 +151,20 @@ where
         Ok(())
     }
 
+    /// Fill the display with a pattern of different brightness values, where the brightness should range from 0 to 255. 
+    /// Blink is not being set.
+    pub fn fill_pattern(&mut self, pattern: &[[u8; 24];6], brightness: u8, frame: u8) -> Result<(), I2cError> {
+        self.bank(frame)?;
+        let mut payload = [brightness; 25];
+        for row in 0..6 {
+            payload[0] = addresses::COLOR_OFFSET + row * 24;
+            payload[1..].copy_from_slice(&pattern[row as usize]);
+            self.i2c.write(self.address, &payload)?;
+        }
+        Ok(())
+    }
+
+
     fn write_register(&mut self, bank: u8, register: u8, value: u8) -> Result<(), I2cError> {
         self.bank(bank)?;
         self.i2c.write(self.address, &[register, value])?;
@@ -159,6 +176,9 @@ where
             .write(self.address, &[addresses::BANK_ADDRESS, bank])?;
         Ok(())
     }
+
+
+    
 }
 
 /// See the [data sheet](https://www.lumissil.com/assets/pdf/core/IS31FL3731_DS.pdf)


### PR DESCRIPTION
Hi,

I updated the driver to use embedded-hal 1.0.0, tested with embassy on ESP32C3 and C6 boards. I also added a definition of a new device, Pimoroni 5x5 RGB matrix (https://shop.pimoroni.com/products/5x5-rgb-matrix-breakout?variant=21375941279827), as the original rgb_matrix_5x5 didn't seem to work right with it. The new one correctly addresses the pixels with x, y coordinates, etc.
I also added a fill_pattern function, which pushes an entire buffer to the matrix just as if you worked with an OLED screen. My intention is to add an example with the standard 9x16 Matrix device. 

I'm just not sure how you want to handle the examples: is it OK to put subfolders in examples, which would contain the relevant Cargo.toml, code etc.? This way there could be examples for different boards, e.g. ESP32 and RP2040/2350.